### PR TITLE
Updated API URL for livestreams

### DIFF
--- a/resources/lib/comm.py
+++ b/resources/lib/comm.py
@@ -22,7 +22,7 @@ def fetch_url(url, headers=None):
 
 def get_matches():
     video_list = []
-    data = fetch_url(config.MATCHES_URL)
+    data = fetch_url(config.LIVETV_URL)
     try:
         video_data = json.loads(data)
     except ValueError:
@@ -30,7 +30,7 @@ def get_matches():
         raise Exception('Failed to retrieve video data. Service may be '
                         'currently unavailable.')
 
-    for match in video_data['matchList']['matches']:
+    for match in video_data['liveMatches']:
         live_streams = match.get('liveStreams')
         if not live_streams:
             live_stream = match.get('liveStream')

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -5,6 +5,8 @@ VIDEOS_URL = 'https://apinew.cricket.com.au/videos?Limit=30'
 
 MATCHES_URL = 'https://apinew.cricket.com.au/matches?inProgressLimit=15&completedLimit=0&upcomingLimit=0&format=json'
 
+LIVETV_URL = 'https://apinew.cricket.com.au/matches/livetv'
+
 MATCH_STREAM_URL = 'https://edge.api.brightcove.com/playback/v1/accounts/807051129001/videos/'
 
 BRIGHTCOVE_PK = 'BCpkADawqM17uKWqEHlBulux385QZ_BoC6x04LRDmsykNRb4uwwRJ8x38iHNk-7kxEqJUu3qZGMFCiKA4d8SeUB0c40Z46CutsbR219abTqUHi82DqCZMUJo36s'


### PR DESCRIPTION
Hi,

The livestream data doesn't seem to be provided by the CA API in the matches URL anymore. The livetv URL seems to work ok, with minimal changes required to the source. Thought you might like to check this out.

My github-fu is not very strong, so apologies if this is incomplete.